### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Want to add your own entry to the LFEX ``.plan`` file? Just:
 
 1. [fork the repo](https://github.com/lfex/plan/fork)
 2. make your edits:
-   * add ``<yourname>`` to the ``src/_config.yml`` in the ``DotFile -> planners`` list
+   * add ``<yourname>`` to the ``src/_config.yml`` in the ``DotPlan -> planners`` list
    * create ``src/plans/<yourname>.plan.md``, adding your LFE/LFEX-related content
    * check your edits locally by running ``make run`` and then opening [http://localhost:4000](http://localhost:4000) in your browser
 3. [submit a PR](https://github.com/lfex/plan/compare)


### PR DESCRIPTION
Replace `DotFile` with `DotPlan` in [README.md](https://github.com/lfex/plan/blob/master/README.md) to properly reflect [src/_config.yml](https://github.com/lfex/plan/blob/fb71598d7df96d8691a101391263b35cc9bceb15/src/_config.yml#L43).
